### PR TITLE
Add subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To initialize the store call `cedux_init_x()`. This sets up the internal list an
 `cedux_register_x_reducer(store, reducer)` where `store` is a pointer to the store created by `CEDUX_DEFINE_STORE` and `reducer` is a function pointer to a reducer function. The reducer function must have a signature of `void reducer(<tree type pointer>, action)`
 
 #### Register Subscribers (Optional)
-`cedux_register_x_subscriber(store, subscriber_container)` where `store` is a pointer to the store created by `CEDUX_DEFINE_STORE` and `subscriber_container` is a pointer to a simple struct containing the subscriber function and optionally extra data to be passed with each call to the subscriber. The subscriber function must have a signature of `void subscriber(<tree type pointer>, void *data)`.  Cedux does not look at or modify `data` at all, so you can use it for whatever extra information you need, or just set it to `NULL` and ignore it.
+`cedux_register_x_subscriber(store, subscriber, data)` where `store` is a pointer to the store created by `CEDUX_DEFINE_STORE`, `subscriber` is the subscriber function, and `data` is optional extra data to be passed with each call to the subscriber. The subscriber function must have a signature of `void subscriber(<tree type pointer>, void *data)`.  Cedux does not look at or modify `data` at all, so you can use it for whatever extra information you need, or just set it to `NULL` and ignore it.
 
 #### Dispatch Actions
 Call the dispatch function to send an action to the store. This method pushes the action into the stores action queue to be handled later by the run function.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It works like this:
   - Application state is stored in a global tree which is created by the `CEDUX_DEFINE_STORE()` macro.
   - Producers of data dispatch actions to the store via calls to `cedux_dispatch_x()`.
   - _Reducers_, which are registered during application initialization, receive dispatched actions and the current state tree and are responsible for updating the state as needed.
+  - Optional _Subscribers_, which are also registered during application initialization, receive the new state tree after reducers process any actions.
   - In the `main` loop, calls to `cedux_run_x()` check for dispatched actions and forward them to all registered reducers.
 
 ## Recommendations
@@ -37,7 +38,10 @@ For example, `CEDUX_DEFINE_STORE(struct my_app_state, struct action, my_store)` 
 To initialize the store call `cedux_init_x()`. This sets up the internals of the internal list and queue.
 
 #### Register Reducers
-`cedux_register_x(store, reducer)` where `store` is a pointer to the store created by `CEDUX_DEFINE_STORE` and reducer is a function pointer to a reducer function. The reducer function must have a signature of `void reducer(<tree type pointer>, action)`
+`cedux_register_x_reducer(store, reducer)` where `store` is a pointer to the store created by `CEDUX_DEFINE_STORE` and `reducer` is a function pointer to a reducer function. The reducer function must have a signature of `void reducer(<tree type pointer>, action)`
+
+#### Register Subscribers (Optional)
+`cedux_register_x_subscriber(store, subscriber_container)` where `store` is a pointer to the store created by `CEDUX_DEFINE_STORE` and `subscriber_container` is a pointer to a simple struct containing the subscriber function and optionally extra data to be passed with each call to the subscriber. The subscriber function must have a signature of `void subscriber(<tree type pointer>, void *data)`.  Cedux does not look at or modify `data` at all, so you can use it for whatever extra information you need, or just set it to `NULL` and ignore it.
 
 #### Dispatch Actions
 Call the dispatch function to send an action to the store. This method pushes the action into the stores action queue to be handled later by the run function.

--- a/cedux.h
+++ b/cedux.h
@@ -9,11 +9,20 @@
                                                                                                 \
 struct STORE_NAME##_handle;                                                                     \
 typedef void(*STORE_NAME##_REDUCER)(TREE_TYPE * p_tree, ACTION_TYPE action);                    \
+typedef void(*STORE_NAME##_SUBSCRIBER)(const TREE_TYPE * p_tree, void *data);                   \
+struct STORE_NAME##_subscriber_container                                                        \
+{                                                                                               \
+    STORE_NAME##_SUBSCRIBER subscriber;                                                         \
+    void *data;                                                                                 \
+};                                                                                              \
 QUEUE_DECLARATION(STORE_NAME##_action_queue, ACTION_TYPE, 16)                                   \
 LIST_DECLARATION(STORE_NAME##_reducer_list, STORE_NAME##_REDUCER, 32)                           \
+LIST_DECLARATION(STORE_NAME##_subscriber_list, struct STORE_NAME##_subscriber_container *, 32)  \
                                                                                                 \
 void cedux_register_##STORE_NAME##_reducer(struct STORE_NAME##_handle * p_store,                \
                                            STORE_NAME##_REDUCER reducer);                       \
+void cedux_register_##STORE_NAME##_subscriber(struct STORE_NAME##_handle * p_store,             \
+                                              struct STORE_NAME##_subscriber_container * subscriber); \
 void cedux_init_##STORE_NAME(struct STORE_NAME##_handle * p_store);                             \
 void cedux_dispatch_##STORE_NAME(struct STORE_NAME##_handle * p_store, ACTION_TYPE action);     \
 bool cedux_run_##STORE_NAME(struct STORE_NAME##_handle * p_store);                              \
@@ -22,6 +31,7 @@ struct STORE_NAME##_handle                                                      
   TREE_TYPE tree;                                                                               \
   struct STORE_NAME##_action_queue action_queue;                                                \
   struct STORE_NAME##_reducer_list reducer_list;                                                \
+  struct STORE_NAME##_subscriber_list subscriber_list;                                          \
 } STORE_NAME;
 
 
@@ -29,15 +39,22 @@ struct STORE_NAME##_handle                                                      
                                                                                                 \
 QUEUE_DEFINITION(STORE_NAME##_action_queue, ACTION_TYPE)                                        \
 LIST_DEFINITION(STORE_NAME##_reducer_list, STORE_NAME##_REDUCER)                                \
+LIST_DEFINITION(STORE_NAME##_subscriber_list, struct STORE_NAME##_subscriber_container *)       \
                                                                                                 \
 void cedux_register_##STORE_NAME##_reducer(struct STORE_NAME##_handle * p_store,                \
                                           STORE_NAME##_REDUCER reducer) {                       \
   STORE_NAME##_reducer_list_push(&p_store->reducer_list, &reducer);                             \
 }                                                                                               \
                                                                                                 \
+void cedux_register_##STORE_NAME##_subscriber(struct STORE_NAME##_handle * p_store,             \
+                                              struct STORE_NAME##_subscriber_container * subscriber) { \
+  STORE_NAME##_subscriber_list_push(&p_store->subscriber_list, &subscriber);                    \
+}                                                                                               \
+                                                                                                \
 void cedux_init_##STORE_NAME(struct STORE_NAME##_handle * p_store) {                            \
   STORE_NAME##_action_queue_init(&p_store->action_queue);                                       \
   STORE_NAME##_reducer_list_init(&p_store->reducer_list);                                       \
+  STORE_NAME##_subscriber_list_init(&p_store->subscriber_list);                                 \
 }                                                                                               \
                                                                                                 \
 void cedux_dispatch_##STORE_NAME(struct STORE_NAME##_handle * p_store, ACTION_TYPE action) {    \
@@ -47,6 +64,7 @@ void cedux_dispatch_##STORE_NAME(struct STORE_NAME##_handle * p_store, ACTION_TY
 bool cedux_run_##STORE_NAME(struct STORE_NAME##_handle * p_store) {                             \
   ACTION_TYPE action;                                                                           \
   STORE_NAME##_REDUCER reducer;                                                                 \
+  struct STORE_NAME##_subscriber_container *subscriber_container;                               \
   bool did_work = false;                                                                        \
   while(STORE_NAME##_action_queue_dequeue(&p_store->action_queue, &action) == DEQUEUE_RESULT_SUCCESS) \
   {                                                                                             \
@@ -55,6 +73,13 @@ bool cedux_run_##STORE_NAME(struct STORE_NAME##_handle * p_store) {             
       reducer(&p_store->tree, action);                                                          \
     }                                                                                           \
     did_work = true;                                                                            \
+  }                                                                                             \
+  if (did_work)                                                                                 \
+  {                                                                                             \
+    LIST_FOR_EACH(p_store->subscriber_list, subscriber_container)                               \
+    {                                                                                           \
+      subscriber_container->subscriber(&p_store->tree, subscriber_container->data);             \
+    }                                                                                           \
   }                                                                                             \
   return did_work;                                                                              \
 }

--- a/example.c
+++ b/example.c
@@ -62,17 +62,8 @@ int main(void)
   my_store = cedux_init_my_store(); // Initialize the internals of the store (list, queue)
 
   cedux_register_my_store_reducer(&my_store, reducer_1);
-
-  struct my_store_subscriber_container container1 = {
-    .subscriber = subscriber_func,
-    .data = (void *)1,
-  };
-  struct my_store_subscriber_container container2 = {
-    .subscriber = subscriber_func,
-    .data = (void *)2,
-  };
-  cedux_register_my_store_subscriber(&my_store, &container1);
-  cedux_register_my_store_subscriber(&my_store, &container2);
+  cedux_register_my_store_subscriber(&my_store, subscriber_func, (void *)1);
+  cedux_register_my_store_subscriber(&my_store, subscriber_func, (void *)2);
 
   setup_timer();
 

--- a/main.c
+++ b/main.c
@@ -46,16 +46,34 @@ void reducer_1(struct tree * p_tree, struct my_action_def action)
   } 
 }
 
+void subscriber_func(const struct tree * p_tree, void *data)
+{
+  int number = (int)data;
+  printf("Subscriber %d: Num leaves %d!\n", number, p_tree->a.leaves);
+}
+
 int main(void)
 {
   cedux_init_my_store(&my_store);
   cedux_register_my_store_reducer(&my_store, reducer_1);
+
+  struct my_store_subscriber_container container1 = {
+    .subscriber = subscriber_func,
+    .data = (void *)1,
+  };
+  struct my_store_subscriber_container container2 = {
+    .subscriber = subscriber_func,
+    .data = (void *)2,
+  };
+  cedux_register_my_store_subscriber(&my_store, &container1);
+  cedux_register_my_store_subscriber(&my_store, &container2);
+
   setup_timer();
 
   while(1) {
     bool did_work = cedux_run_my_store(&my_store);
     if (did_work) {
-      printf("Num leaves %d!\n", my_store.tree.a.leaves);
+      printf("Did work.\n");
     }
   } 
 }


### PR DESCRIPTION
Fixes #3 .

I was on the fence about the extra `data` field.  It could definitely be useful, but at the same time it complicates registering the subscriber.  (For instance, the user will have to pay attention to how and where the container object is allocated).  Could remove it pretty easily if needed.