### PR TITLE
Added linked subscribers

### DIFF
--- a/example.c
+++ b/example.c
@@ -8,12 +8,17 @@
 void timer_handler (int signum);
 void setup_timer(void);
 
+// HEADER DETAILS *************************************************************************************
+// Normally this code would be in a header file. For the sake of having a concise demo, I'm putting it
+// all in one file.
+//
 struct branch_a { int leaves; };
 struct tree { struct branch_a a; };
 
 enum action_type {
   ADD_LEAVES,
   REMOVE_LEAVES,
+  BURN_THE_TREE,
 };
 
 struct add_leaves_data { int count; };
@@ -28,61 +33,115 @@ struct my_action_def {
   };
 };
 
-// Normally this would be in a header file. This line defines a struct
-// for the store handles called 'struct my_store_handle'
+// This macro declares the store data structure as well as all of the functions which are needed
+// to register reducers, and subscribers, and dispatch actions. It also declares the cedux_run_my_store
+// function.
 CEDUX_DECLARE_STORE(struct tree, struct my_action_def, my_store);
 
+//
+//  END OF HEADER CONTENT
+// ****************************************************************************************************
+
+
+// This macro defines the implementation of the functions which are used to register reducers,
+// subscribers, and dispatch actions. It also defines the cedux_run_my_store function.
 CEDUX_DEFINE_STORE(struct tree, struct my_action_def, my_store);
 
 struct my_store_handle my_store;
 
-void reducer_1(struct tree * p_tree, struct my_action_def action) 
+bool primary_reducer(struct tree * p_tree, struct my_action_def action) 
 {
+  // Reducers are the ONLY place where the state tree should be modified.
+  // Return true if the state is updated. Otherwise return false.
   switch (action.type)
   {
     case ADD_LEAVES:
       p_tree->a.leaves += action.add_leaves_data.count;
-      break;
+      return true;
     case REMOVE_LEAVES:
-      p_tree->a.leaves -= action.add_leaves_data.count;
-      break;
+      p_tree->a.leaves -= action.subtract_leaves_data.count;
+      if (p_tree->a.leaves < 0) { p_tree->a.leaves = 0; }
+      return true;
     default:
-      break;
+      return false;
   } 
 }
 
-void subscriber_func(const struct tree * p_tree, void *data)
+bool burn_tree_reducer(struct tree * p_tree, struct my_action_def action)
+{
+  // Reducers are the ONLY place where the state tree should be modified.
+  // Return true if the state is updated. Otherwise return false.
+  if (action.type == BURN_THE_TREE) {
+    p_tree->a.leaves = 0;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void generic_subscriber(struct my_store_handle * p_store, struct tree const * const p_tree, void *data)
+{
+  // Subscribers are for performing side-effects. Ideally they should be pure functions which perform some
+  // action as a result of a state change.
+  // The store handle is passed in so that you can dispatch new actions within here if you want to.
+  // The state tree is passed in so that you can reference the state. It's const so you shouldn't modify it.
+  int number = (int)data;
+  printf("Generic Subscriber.  Num leaves %d! Data: %d:\n", p_tree->a.leaves, number);
+}
+
+void linked_subscriber(struct my_store_handle * p_store, struct tree const * const p_tree, void *data)
 {
   int number = (int)data;
-  printf("Subscriber %d: Num leaves %d!\n", number, p_tree->a.leaves);
+  printf("The tree burned down!!  Num leaves %d. Data: %d:\n", p_tree->a.leaves, number);
 }
 
 int main(void)
 {
   my_store = cedux_init_my_store(); // Initialize the internals of the store (list, queue)
 
-  cedux_register_my_store_reducer(&my_store, reducer_1);
-  cedux_register_my_store_subscriber(&my_store, subscriber_func, (void *)1);
-  cedux_register_my_store_subscriber(&my_store, subscriber_func, (void *)2);
+  // Setup initial state.
+  my_store.tree.a.leaves = 1000;
 
-  setup_timer();
+  // Register reducers
+  cedux_register_my_store_reducer(&my_store, primary_reducer);
+  cedux_register_my_store_reducer(&my_store, burn_tree_reducer);
+
+  // Register a generic subscriber. Generic subscribers will always run any time any reducer does work.
+  cedux_register_my_store_subscriber(&my_store, generic_subscriber, (void *)1);
+  // You can register additional subscribers which get a unique "context". That context will always be
+  // baseed to the subscriber.
+  cedux_register_my_store_subscriber(&my_store, generic_subscriber, (void *)2);
+  // You can also register a linked subscriber that will only get called if the 
+  // reducer that it is linked to does work.
+  cedux_register_my_store_linked_subscriber(&my_store, linked_subscriber, (void *)3, burn_tree_reducer);
+
+  setup_timer(); // Setup for demo
 
   while(1) {
-    bool did_work = cedux_run_my_store(&my_store);
+    bool did_work = cedux_run_my_store(&my_store); // REQUIRED. You must call this every run of your main loop. This is where all the magic happens.
     if (did_work) {
-      printf("Did work.\n");
+      printf("A reducer did work.\n");
     }
   } 
 }
 
 void timer_handler (int signum)
 {
-  cedux_dispatch_my_store(&my_store, (struct my_action_def){
-    .type = rand() % 2 != 1 ? ADD_LEAVES : REMOVE_LEAVES,
-    .add_leaves_data = {
-        .count = rand() % 100
-    }
-  });
+  // Create an action and fill in the data based on some randomness...
+  int random_val = rand();
+  printf("Random num: %d\n", random_val);
+  struct my_action_def action;
+  action.type = rand() % 2 != 1 ? ADD_LEAVES : REMOVE_LEAVES;
+  // Every so often burn down the tree!
+  action.type = (random_val % 4 == 0) ? BURN_THE_TREE : action.type;
+  if (action.type == ADD_LEAVES) {
+    action.add_leaves_data.count = random_val % 100;
+  } else if (action.type == REMOVE_LEAVES) {
+    action.subtract_leaves_data.count = random_val % 100;
+  }
+
+  // Dispatch the action
+  cedux_dispatch_my_store(&my_store, action);
 }
 
 void setup_timer(void)

--- a/queue.h
+++ b/queue.h
@@ -1,5 +1,6 @@
 #ifndef QUEUE_H
 #define QUEUE_H
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -14,14 +15,16 @@ enum dequeue_result {
   DEQUEUE_RESULT_EMPTY,
 };
 
-#define ARRAY_LENGTH(A) (sizeof(A)/sizeof((A)[0])) 
+#define ARRAY_LENGTH(A) (sizeof(A)/sizeof((A)[0]))
 
-#define QUEUE_DECLARATION(NAME, ITEM_TYPE, NUM_ITEMS)                                   \
+#define QUEUE_TYPE_DECLARATION(NAME, ITEM_TYPE, NUM_ITEMS)                              \
 struct NAME {                                                                           \
   uint16_t read_idx;                                                                    \
   uint16_t write_idx;                                                                   \
   ITEM_TYPE items[NUM_ITEMS];                                                           \
-};                                                                                      \
+};
+
+#define QUEUE_DECLARATION(NAME, ITEM_TYPE)                                              \
 void NAME ## _init(struct NAME * p_queue);                                              \
 enum enqueue_result NAME ##_enqueue(struct NAME * p_queue, ITEM_TYPE * p_new_item);     \
 enum dequeue_result NAME ##_dequeue(struct NAME * p_queue, ITEM_TYPE * p_item_out);     \


### PR DESCRIPTION
This change adds a new feature called `linked subscribers`. A linked subscriber is linked to a specific reducer function. When that reducer function runs and does work, the subscriber will then run. This allows subscribers to run only when relevant state changes.

I also updated the subscriber function signature so that it takes a store handle. This makes it easy for subscriber functions to dispatch actions if needed.

I'm open for feedback and discussion from anyone who's watching :) 